### PR TITLE
Add HTTP Headers to Web Service Listener

### DIFF
--- a/client/src/com/mirth/connect/connectors/ws/WebServiceListener.java
+++ b/client/src/com/mirth/connect/connectors/ws/WebServiceListener.java
@@ -56,6 +56,7 @@ public class WebServiceListener extends ConnectorSettingsPanel {
         properties.setClassName(classNameField.getText());
         properties.setServiceName(serviceNameField.getText());
         properties.setSoapBinding(Binding.fromDisplayName((String) versionComboBox.getSelectedItem()));
+        properties.setHttpHeaders(httpHeadersField.getText());
 
         return properties;
     }
@@ -71,6 +72,7 @@ public class WebServiceListener extends ConnectorSettingsPanel {
         updateClassNameRadio();
 
         serviceNameField.setText(props.getServiceName());
+        httpHeadersField.setText(props.getHttpHeaders());
 
         updateWSDL();
     }
@@ -149,6 +151,7 @@ public class WebServiceListener extends ConnectorSettingsPanel {
         methodLabel = new JLabel("Method:");
         webServiceLabel = new JLabel("Web Service:");
         classNameLabel = new JLabel("Service Class Name:");
+        httpHeadersLabel = new JLabel("HTTP Headers:");
 
         serviceNameField = new MirthTextField();
         serviceNameField.setToolTipText("The name to give to the web service.");
@@ -205,6 +208,9 @@ public class WebServiceListener extends ConnectorSettingsPanel {
 
         classNameField = new MirthTextField();
         classNameField.setToolTipText("<html>The fully qualified class name of the web service that should be hosted.<br>If this is a custom class, it should be added in a custom jar so it is loaded with Mirth Connect.</html>");
+
+        httpHeadersField = new MirthTextField();
+        httpHeadersField.setToolTipText("Displays the HTTP Headers of incoming calls.");
     }
 
     private void initLayout() {
@@ -230,6 +236,9 @@ public class WebServiceListener extends ConnectorSettingsPanel {
 
         add(methodLabel);
         add(methodField, "w 250!, wrap");
+
+        add(httpHeadersLabel);
+        add(httpHeadersField, "w 250!, wrap");
     }
 
     private void serviceNameFieldKeyReleased(KeyEvent evt) {
@@ -269,4 +278,7 @@ public class WebServiceListener extends ConnectorSettingsPanel {
 
     private JLabel methodLabel;
     private JTextField methodField;
+
+    private JLabel httpHeadersLabel;
+    private MirthTextField httpHeadersField;
 }

--- a/core-server-plugins/src/com/mirth/connect/connectors/core/ws/IWebServiceReceiver.java
+++ b/core-server-plugins/src/com/mirth/connect/connectors/core/ws/IWebServiceReceiver.java
@@ -7,4 +7,5 @@ public interface IWebServiceReceiver extends ISourceConnector {
 
 	public void setServer(HttpServer server);
 	
+	public Map<String, List<String>> getHttpHeaders();
 }

--- a/core-server-plugins/src/com/mirth/connect/connectors/core/ws/WebServiceConfiguration.java
+++ b/core-server-plugins/src/com/mirth/connect/connectors/core/ws/WebServiceConfiguration.java
@@ -23,4 +23,6 @@ public interface WebServiceConfiguration {
     public void configureReceiver(IWebServiceReceiver connector) throws Exception;
 
     public void configureDispatcher(IWebServiceDispatcher connector, ConnectorProperties connectorProperties, Map<String, Object> requestContext) throws Exception;
+
+    public void configureHttpHeaders(IWebServiceReceiver connector) throws Exception;
 }

--- a/server/src/com/mirth/connect/connectors/ws/WebServiceReceiver.java
+++ b/server/src/com/mirth/connect/connectors/ws/WebServiceReceiver.java
@@ -87,6 +87,7 @@ public class WebServiceReceiver extends SourceConnector implements IWebServiceRe
     private WebServiceReceiverProperties connectorProperties;
     private HttpAuthConnectorPluginProperties authProps;
     private AuthenticatorProvider authenticatorProvider;
+    private Map<String, List<String>> httpHeaders;
 
     @Override
     public void onDeploy() throws ConnectorTaskException {
@@ -344,6 +345,11 @@ public class WebServiceReceiver extends SourceConnector implements IWebServiceRe
         this.server = server;
     }
 
+    @Override
+    public Map<String, List<String>> getHttpHeaders() {
+        return httpHeaders;
+    }
+
     private com.sun.net.httpserver.Authenticator createAuthenticator() throws ConnectorTaskException {
         final Authenticator authenticator;
         try {
@@ -363,6 +369,7 @@ public class WebServiceReceiver extends SourceConnector implements IWebServiceRe
                 String method = StringUtils.trimToEmpty(exch.getRequestMethod());
                 String requestURI = StringUtils.trimToEmpty(exch.getRequestURI().toString());
                 Map<String, List<String>> headers = exch.getRequestHeaders();
+                httpHeaders = headers;
 
                 Map<String, List<String>> queryParameters = new LinkedHashMap<String, List<String>>();
                 for (NameValuePair nvp : URLEncodedUtils.parse(exch.getRequestURI(), "UTF-8")) {


### PR DESCRIPTION
Fixes #6337

Add functionality to display HTTP Headers in Web Service Listener connector.

* **WebServiceListener.java**:
  - Add `httpHeadersField` to display HTTP Headers.
  - Update `initComponents` to initialize `httpHeadersField`.
  - Update `initLayout` to add `httpHeadersField` to the layout.
  - Update `setProperties` and `getProperties` methods to handle HTTP Headers.

* **IWebServiceReceiver.java**:
  - Add `getHttpHeaders` method to the interface.

* **WebServiceConfiguration.java**:
  - Add `configureHttpHeaders` method to handle HTTP Headers.

* **WebServiceReceiver.java**:
  - Add `httpHeaders` field to store HTTP Headers.
  - Implement `getHttpHeaders` method to return HTTP Headers.
  - Update `createAuthenticator` method to store HTTP Headers from `HttpExchange`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nextgenhealthcare/connect/issues/6337?shareId=XXXX-XXXX-XXXX-XXXX).